### PR TITLE
Unmask videoUrl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 videos
 tmp
+node_modules
+*.log

--- a/src/download.coffee
+++ b/src/download.coffee
@@ -70,12 +70,18 @@ writeFile = ({ videoUrl, filePath, fileName }, callback)->
     callback()
   catch err
     console.log "Downloading: #{fileName}"
+    unmaskedVideoUrl = await unmaskUrl(videoUrl)
 
     file = fs.createWriteStream(filePath)
-    https.get videoUrl, (resp)->
+    https.get unmaskedVideoUrl, (resp)->
       resp.pipe(file)
       file.on 'finish', ->
         file.close()
         callback()
+
+unmaskUrl = (videoUrl) -> 
+  resp = await request(videoUrl)
+  return resp
+
 
 module.exports = downloadSeries


### PR DESCRIPTION
I don't know if egghead changed something, but the script wasn't working for me. Instead of getting the actual videoUrl they return a link with an expiration date. Using this link will get the actual video.